### PR TITLE
patch_1.1.3: Exit and print usage upon invalid argument

### DIFF
--- a/dns_updater.rb
+++ b/dns_updater.rb
@@ -76,7 +76,7 @@ class DNSUpdater
   end
 
   def self.version
-    version = '1.1.2'
+    version = '1.1.3'
   end
 
   # Creates a new DNS Updater config file
@@ -309,7 +309,8 @@ if __FILE__ == $PROGRAM_NAME
   config = YAML.load_file(config_file)
   daemon = Daemon.new(config)
 
-  unless %w(status start stop restart).include?(ARGV.first)
+  if ARGV.empty?
+  # unless %w(status start stop restart).include?(ARGV.first)
     puts 'No action provided! Running once to update all domains!'
     daemon.run
     puts 'All finished!'
@@ -325,5 +326,8 @@ if __FILE__ == $PROGRAM_NAME
     daemon.stop
   when 'restart'
     daemon.restart
+  else
+    puts "ERROR: Invalid argument provided: #{ARGV.first}"
+    abort(@usage.lines[0..3].join)
   end
 end


### PR DESCRIPTION
- Typo'd command line arguments other than [start, stop, status, restart] were causing a run-once. The program now properly exits and prints a snippet of Usage information if an invalid argument is provided. No argument will still do a single run.